### PR TITLE
ENG-1364 updated content type attribute descriptor with latest changes on core

### DIFF
--- a/lib/env-bundler.js
+++ b/lib/env-bundler.js
@@ -298,7 +298,25 @@ const componentResponseProcessor = {
         headers: { Authorization: `Bearer ${token}` },
       });
 
-      contentType.attributes = res.data.payload.attributes;
+      const schema = {
+        'code': 'code',
+        'type': 'type',
+        'names': 'names',
+        'roles': 'roles',
+        'disablingCodes': 'disablingCodes',
+        'mandatory': 'mandatory',
+        'listFilter': 'listFilter',
+        'indexable': 'indexable',
+        'enumeratorExtractorBean': 'enumeratorExtractorBean',
+        'enumeratorStaticItems': 'enumeratorStaticItems',
+        'enumeratorStaticItemsSeparator': 'enumeratorStaticItemsSeparator',
+        'validationRules': 'validationRules',
+        'nestedAttribute': 'nestedAttribute',
+        'compositeAttributes': 'compositeAttributes',
+      };
+
+      contentType.attributes = res.data.payload.attributes.map(a => objectMapper(a, schema));
+
       return contentType;
     }));
 


### PR DESCRIPTION
`name` was replaced by an i18n map called `names`.

Related to PR on entando-engine:
 - https://github.com/entando/entando-engine/pull/40